### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:14
+WORKDIR /app
+COPY . /app
+RUN npm run auto-install
+EXPOSE 3030
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.9"
+services:
+  cad:
+    build: .
+    restart: always
+    ports:
+      - "3030:3030"
+    environment: 
+      DB_HOST: database
+      DB_NAME: snaily-cad
+      DB_PASSWORD: p69gTywJwQ2wJ64S
+      JWT_SECRET: 3bCPHdeHQPuPnXyG
+      PORT: 3030
+    depends_on:
+      - database
+  database:
+    image: "mariadb:10.4.17"
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./snaily-cad.sql:/docker-entrypoint-initdb.d/001_init.sql
+    restart: always
+    ports:
+      - "3306:3306"
+    environment: 
+      MYSQL_DATABASE: snaily-cad
+      MYSQL_ROOT_PASSWORD: p69gTywJwQ2wJ64S
+volumes:
+  db_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,17 @@ services:
       PORT: 3030
     depends_on:
       - database
+  admin:
+    image: "phpmyadmin:5.1.0"
+    restart: always
+    ports:
+      - "8080:80"
+    environment: 
+      PMA_HOST: database
+      PMA_PORT: 3306
+      MYSQL_ROOT_PASSWORD: p69gTywJwQ2wJ64S
+    depends_on:
+      - database
   database:
     image: "mysql:5.7"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - database
   database:
-    image: "mariadb:10.4.17"
+    image: "mysql:5.7"
     volumes:
       - db_data:/var/lib/mysql
       - ./snaily-cad.sql:/docker-entrypoint-initdb.d/001_init.sql

--- a/server/config.example.ts
+++ b/server/config.example.ts
@@ -1,11 +1,11 @@
 const config = {
-  port: 3030,
-  host: "localhost",
-  user: "root",
-  password: "admin",
-  databaseName: "snaily-cad",
-  jwtSecret: "bongo super cat" /* change this to a long random string of numbers and characters */,
-  env: "production" /* Do NOT change this unless you know what you are doing! */,
+  port: Number(process.env.PORT) || 3030,
+  host: process.env.DB_HOST || "localhost",
+  user: process.env.DB_USER || "root",
+  password: process.env.DB_PASSWORD || "admin",
+  databaseName: process.env.DB_NAME || "snaily-cad",
+  jwtSecret: process.env.JWT_SECRET || "bongo super cat" /* change this to a long random string of numbers and characters */,
+  env: process.env.PROFILE || "production" /* Do NOT change this unless you know what you are doing! */,
 };
 
 export default config;


### PR DESCRIPTION
Updated config.example.ts to support environment variable configuration (used in docker-compose).

How to use:
* ensure you have Docker desktop installed on your machine;
* navigate to project root;
* run command `docker-compose up` (to run as a background process use `docker-compose up -d`)
* wait until service boots up and check http://localhost:3030

Not sure if it should be MySQL 5.7 or MySQL 8. This also worked with MariaDB 10.4.17.