### PR TITLE
manage server config through .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ build
 node_modules
 
 # config
-server/config.ts
 client/src/config.ts
 
 server/public/citizen-images/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ services:
     ports:
       - "3030:3030"
     environment: 
-      DB_HOST: database
-      DB_NAME: snaily-cad
-      DB_PASSWORD: p69gTywJwQ2wJ64S
-      JWT_SECRET: 3bCPHdeHQPuPnXyG
+      DB_HOST: "${DB_HOST}"
+      DB_NAME: "${DB_NAME}"
+      DB_PASSWORD: "${DB_PASSWORD}"
+      JWT_SECRET: "${JWT_SECRET}"
       PORT: 3030
     depends_on:
       - database
@@ -19,9 +19,9 @@ services:
     ports:
       - "8080:80"
     environment: 
-      PMA_HOST: database
+      PMA_HOST: "${DB_HOST}"
       PMA_PORT: 3306
-      MYSQL_ROOT_PASSWORD: p69gTywJwQ2wJ64S
+      MYSQL_ROOT_PASSWORD: "${DB_PASSWORD}"
     depends_on:
       - database
   database:
@@ -33,7 +33,7 @@ services:
     ports:
       - "3306:3306"
     environment: 
-      MYSQL_DATABASE: snaily-cad
-      MYSQL_ROOT_PASSWORD: p69gTywJwQ2wJ64S
+      MYSQL_DATABASE: "${DB_NAME}"
+      MYSQL_ROOT_PASSWORD: "${DB_PASSWORD}"
 volumes:
   db_data: {}

--- a/server/config.ts
+++ b/server/config.ts
@@ -7,9 +7,9 @@ const config = {
   port: Number(process.env.PORT) || 3030,
   host: process.env.DB_HOST || "localhost",
   user: process.env.DB_USER || "root",
-  password: process.env.DB_PASSWORD || "admin",
+  password: process.env.DB_PASSWORD,
   databaseName: process.env.DB_NAME || "snaily-cad",
-  jwtSecret: process.env.JWT_SECRET || "bongo super cat",
+  jwtSecret: process.env.JWT_SECRET,
   env: process.env.PROFILE || "production",
 };
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,12 +13,12 @@ const app: Application = express();
 const port = config.port;
 const server = app.listen(port, () => {
   if (!config.password) {
-    Logger.log('ERROR', 'DB_PASSWORD is missing! Did you forget to set up .env file in server folder?')
-  } 
-  if (!config.jwtSecret) {
-    Logger.log('ERROR', 'JWT_SECRET is missing! Did you forget to set up .env file in server folder?')
+    Logger.log("ERROR", "DB_PASSWORD is missing! Did you forget to set up .env file in server folder?");
   }
-  Logger.listening(port)
+  if (!config.jwtSecret) {
+    Logger.log("ERROR", "JWT_SECRET is missing! Did you forget to set up .env file in server folder?");
+  }
+  Logger.listening(port);
 });
 
 const io = new Server(server, {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -11,7 +11,15 @@ import config from "../config";
 
 const app: Application = express();
 const port = config.port;
-const server = app.listen(port, () => Logger.listening(port));
+const server = app.listen(port, () => {
+  if (!config.password) {
+    Logger.log('ERROR', 'DB_PASSWORD is missing! Did you forget to set up .env file in server folder?')
+  } 
+  if (!config.jwtSecret) {
+    Logger.log('ERROR', 'JWT_SECRET is missing! Did you forget to set up .env file in server folder?')
+  }
+  Logger.listening(port)
+});
 
 const io = new Server(server, {
   cors: {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,10 +13,16 @@ const app: Application = express();
 const port = config.port;
 const server = app.listen(port, () => {
   if (!config.password) {
-    Logger.log("ERROR", "DB_PASSWORD is missing! Did you forget to set up .env file in server folder?");
+    Logger.log(
+      "ERROR",
+      "DB_PASSWORD is missing! Did you forget to set up .env file in server folder?",
+    );
   }
   if (!config.jwtSecret) {
-    Logger.log("ERROR", "JWT_SECRET is missing! Did you forget to set up .env file in server folder?");
+    Logger.log(
+      "ERROR",
+      "JWT_SECRET is missing! Did you forget to set up .env file in server folder?",
+    );
   }
   Logger.listening(port);
 });


### PR DESCRIPTION
Prevent credential leaks & default credential usage by server owners.

`.env` file should be created in `server` folder.

`.env` for `npm run start`
```
DB_HOST=localhost
DB_NAME=snaily-cad
DB_PASSWORD=YOUR_DB_PW_HERE
JWT_SECRET=YOUR_JWT_SECRET_HERE
PROFILE=production
```

`.env` for **Docker**
```
DB_HOST=database
DB_NAME=snaily-cad
DB_PASSWORD=YOUR_DB_PW_HERE
JWT_SECRET=YOUR_JWT_SECRET_HERE
PROFILE=production
```

**Docker** `.env` usage:
`docker-compose --env-file ./server/.env up`

Works straight out of the box in the case of `npm run start` as dotenv node module exists.

--------------------------
This affects existing users who have made their own `config.ts` file (previously in .gitignore).