### PR TITLE
Rework docker build logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,22 @@
-FROM node:14
-WORKDIR /app
-COPY . /app
+FROM node:14.16.0-alpine3.13 as build
+
+COPY . /build
+
+WORKDIR /build
+
 RUN npm run auto-install
+
+#
+
+FROM node:14.16.0-alpine3.13
+
+COPY --from=build /build/client/ /app/client
+COPY --from=build /build/server/ /app/server
+COPY package.json package-lock.json /app/
+
+COPY server/config.example.ts /app/server/config.ts
+
+WORKDIR /app
+
 EXPOSE 3030
 CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "start:client": "npm run build --prefix client",
     "start:server": "npm start --prefix server",
-    "start": "npm run translation:generate &&  npm run start:client && npm run start:server",
+    "start": "npm run start:server",
     "dev": "concurrently \"npm start --prefix server\" \"npm start --prefix client\"",
-    "auto-install": "node ./scripts/install.js",
+    "auto-install": "node ./scripts/install.js && npm run translation:generate && npm run start:client",
     "update": "node ./scripts/auto-update.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
- Build snailycadv3 on node alpine container instead, which saves alot of its size. From ~1,4G to ~600mb.
- For building container, use multi-stage build, so only required files are copyed to the final container.
- Also move all the build processes to be part of the "auto-install". It doesn't make much sense that service starts doing build processes every time container starts.

As config file support taking variables from environment, just copy it into final container. I think this logic should be changed in future, so we can totally rely getting all the required variables from enviroment.