### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:14.16.0-alpine3.13 as build
+ARG IMAGE_VER="14.16.0-alpine3.13"
+
+FROM node:${IMAGE_VER} as build
 
 COPY . /build
 
@@ -8,13 +10,11 @@ RUN npm run auto-install
 
 #
 
-FROM node:14.16.0-alpine3.13
+FROM node:${IMAGE_VER}
 
 COPY --from=build /build/client/ /app/client
 COPY --from=build /build/server/ /app/server
 COPY package.json package-lock.json /app/
-
-COPY server/config.example.ts /app/server/config.ts
 
 WORKDIR /app
 


### PR DESCRIPTION
- In dockerfile, set base image tag as a variable to remove duplicate code.
- Remove copying of the "config.ts" to final container as #120 enabled us to use env variables for setting up required settings

I also recommend saving docker-compose env file in root directory and not in "server", because otherwise this .env file will be copied to container and this might not be desired behavior.

> docker-compose --env-file .env up --build --remove-orphans
