### PR TITLE
Monitoring health check support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN npm run auto-install
 
 FROM node:${IMAGE_VER}
 
+RUN apk add --update --no-cache curl
+
 COPY --from=build /build/client/ /app/client
 COPY --from=build /build/server/ /app/server
 COPY package.json package-lock.json /app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,15 @@ services:
       DB_PASSWORD: "${DB_PASSWORD}"
       JWT_SECRET: "${JWT_SECRET}"
       PORT: 3030
+    healthcheck:
+      test: curl -sS http://cad:3030/health/liveness || exit 1
+      interval: 5s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     depends_on:
-      - database
+      database:
+        condition: service_healthy
   admin:
     image: "phpmyadmin:5.1.0"
     restart: always
@@ -23,7 +30,8 @@ services:
       PMA_PORT: 3306
       MYSQL_ROOT_PASSWORD: "${DB_PASSWORD}"
     depends_on:
-      - database
+      database:
+        condition: service_healthy
   database:
     image: "mysql:5.7"
     volumes:
@@ -35,5 +43,9 @@ services:
     environment: 
       MYSQL_DATABASE: "${DB_NAME}"
       MYSQL_ROOT_PASSWORD: "${DB_PASSWORD}"
+    healthcheck:
+      test: "/etc/init.d/mysql status"
+      timeout: 5s
+      retries: 3
 volumes:
   db_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       JWT_SECRET: "${JWT_SECRET}"
       PORT: 3030
     healthcheck:
-      test: curl -sS http://cad:3030/health/liveness || exit 1
+      test: curl -f http://cad:3030/health/liveness || exit 1
       interval: 5s
       timeout: 10s
       retries: 3

--- a/server/src/lib/database.ts
+++ b/server/src/lib/database.ts
@@ -18,9 +18,13 @@ export async function connect(): Promise<mysql.Connection> {
 
 export async function processQuery<T = any>(query: string, data?: any[]): Promise<T[]> {
   const conn = await connect();
-  const result = await conn.query(query, data);
-  conn.end();
-  return result;
+  try {
+    return await conn.query(query, data);
+  } finally {
+    if (conn) {
+      conn.end();
+    }
+  }
 }
 
 const interval = setInterval(select1, INTERVAL_5_SECS);

--- a/server/src/monitoring-api.ts
+++ b/server/src/monitoring-api.ts
@@ -1,0 +1,10 @@
+import { Router, json } from "express";
+
+import healthRouter from "./routes/monitoring/health";
+
+const api: Router = Router();
+
+api.use(json());
+api.use("/health", healthRouter);
+
+export default api;

--- a/server/src/routes/monitoring/health.ts
+++ b/server/src/routes/monitoring/health.ts
@@ -1,26 +1,23 @@
 import { Response, Router } from "express";
-import { processQuery } from "../../lib/database"
+import { processQuery } from "../../lib/database";
 import Logger from "../../lib/Logger";
 import IRequest from "../../interfaces/IRequest";
 
 const router: Router = Router();
 
-router.get(
-  "/liveness",
-  async (_: IRequest, res: Response) => {
-    let code = 200;
-    let status = "UP";
+router.get("/liveness", async (_: IRequest, res: Response) => {
+  let code = 200;
+  let status = "UP";
 
-    try {
-      await processQuery("SELECT 1");
-    } catch (err) {
-      code = 500;
-      status = "DOWN";
-      Logger.log("ERROR", `Liveness failed: ${err.message}`);
-    }
+  try {
+    await processQuery("SELECT 1");
+  } catch (err) {
+    code = 500;
+    status = "DOWN";
+    Logger.log("ERROR", `Liveness failed: ${err.message}`);
+  }
 
-    return res.status(code).json({ status });
-  },
-);
+  return res.status(code).json({ status });
+});
 
 export default router;

--- a/server/src/routes/monitoring/health.ts
+++ b/server/src/routes/monitoring/health.ts
@@ -1,0 +1,26 @@
+import { Response, Router } from "express";
+import { processQuery } from "../../lib/database"
+import Logger from "../../lib/Logger";
+import IRequest from "../../interfaces/IRequest";
+
+const router: Router = Router();
+
+router.get(
+  "/liveness",
+  async (_: IRequest, res: Response) => {
+    let code = 200;
+    let status = "UP";
+
+    try {
+      await processQuery("SELECT 1");
+    } catch (err) {
+      code = 500;
+      status = "DOWN";
+      Logger.log("ERROR", `Liveness failed: ${err.message}`);
+    }
+
+    return res.status(code).json({ status });
+  },
+);
+
+export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -7,6 +7,7 @@ import csurf from "csurf";
 import { Server } from "socket.io";
 import Logger from "./lib/Logger";
 import api from "./api";
+import monitoringApi from "./monitoring-api";
 import config from "./lib/config";
 
 const app: Application = express();
@@ -35,6 +36,7 @@ const io = new Server(server, {
 });
 const protection = csurf({ cookie: true });
 app.use("/api/v1", api, protection);
+app.use("", monitoringApi);
 
 app.use("/static", express.static("public"));
 app.use(express.static(path.join(__dirname, "../../client/build")));

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -36,7 +36,7 @@ const io = new Server(server, {
 });
 const protection = csurf({ cookie: true });
 app.use("/api/v1", api, protection);
-app.use("", monitoringApi);
+app.use(monitoringApi);
 
 app.use("/static", express.static("public"));
 app.use(express.static(path.join(__dirname, "../../client/build")));


### PR DESCRIPTION
Add `/health/liveness` endpoint to probe whether service is healthy or not. As of right now it only checks for database availability.