### PR TITLE
Separate node docker build logic from the standard way

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . /build
 
 WORKDIR /build
 
-RUN npm run auto-install
+RUN npm run docker-build
 
 #
 
@@ -21,4 +21,4 @@ COPY package.json package-lock.json /app/
 WORKDIR /app
 
 EXPOSE 3030
-CMD ["npm", "start"]
+CMD ["npm", "run", "docker-start"]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "start": "npm run translation:generate && npm run start:client && npm run start:server",
     "dev": "concurrently \"npm start --prefix server\" \"npm start --prefix client\"",
     "auto-install": "node ./scripts/install.js && npm run translation:generate",
+    "docker-build": "node ./scripts/install.js && npm run translation:generate && npm run start:client",
+    "docker-start": "npm run start:server",
     "update": "node ./scripts/auto-update.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
[This commit](https://github.com/Dev-CasperTheGhost/snaily-cadv3/commit/4971e47abd7b68b62c1b6cac9a1514d87787be7c) broke docker building logic, because now it starts building client every time container starts. Docker containers are versioned themselves and no need to trigger it.