### PR TITLE
[Display Bug] Change text on UpdateUsername Modal

### DIFF
--- a/src/components/modals/account/EditUsernameModal.tsx
+++ b/src/components/modals/account/EditUsernameModal.tsx
@@ -61,7 +61,7 @@ const EditUsernameModalC: React.FC<Props> = ({ updateUsername }) => {
             {lang.global.cancel}
           </button>
           <button type="submit" className="btn btn-primary">
-            {lang.auth.update_password}
+            {lang.auth.update_username}
           </button>
         </div>
       </form>

--- a/src/language.json
+++ b/src/language.json
@@ -7,6 +7,7 @@
         "enter_old_password": "Enter Old Password",
         "confirm_password": "Please confirm your password",
         "update_password": "Update Password",
+        "update_username": "Update Username",
         "no_acc": "Don't have an account?",
         "create_account": "Create Account",
         "has_acc": "Already have an account?",


### PR DESCRIPTION
The update username modal's confirmation button was update password, now changed to update username.